### PR TITLE
Improve Makefile.mingw

### DIFF
--- a/Makefile.mingw
+++ b/Makefile.mingw
@@ -1,6 +1,23 @@
+PKGCONFIG=pkg-config
 OUTPUT=prototracker.exe
 SRC=src/*.cpp src/modules/*.cpp
 SRC_H=src/*.h src/modules/*.h
 
+CXXFLAGS = -D_USE_MATH_DEFINES -DSCALE=2 -Wformat -std=c++11
+LIBS = `$(PKGCONFIG) --cflags --libs sdl2 SDL2_image`
+
+DEBUG ?= 0
+ifeq ($(DEBUG), 1)
+	CXXFLAGS += -g
+else
+	CXXFLAGS += -O3 -s
+endif
+
+STATIC ?= 0
+ifeq ($(STATIC), 1)
+	CXXFLAGS += -static
+	LIBS = `$(PKGCONFIG) --cflags --libs --static sdl2 SDL2_image libpng libtiff-4 libjpeg libwebp`
+endif
+
 $(OUTPUT): $(SRC) $(SRC_H)
-	g++ -DSCALE=2 -O3 -Wformat -std=c++11 -o $@ $(SRC) -lmingw32 -lSDL2_image -lSDL2main -lSDL2 -Ic:/mingw/include/SDL2 -Ic:/tdm-gcc-32/include/SDL2 -g
+	$(CXX) $(CXXFLAGS) -o $@ $(SRC) $(LIBS)


### PR DESCRIPTION
Adds conditionals and more env vars to accomodate the different mingw
environments out there.

For example, to cross-compile a debug build on Arch Linux you could execute:
```bash
CXX=/usr/bin/x86_64-w64-mingw32-g++ \
PKGCONFIG=x86_64-w64-mingw32-pkg-config \
DEBUG=1 make -e mingw
```
While on msys2 mingw-w64 you could just do:
`make mingw STATIC=1`

Switching to pkg-config makes static linking very easy here.
Defaults to release build (without `DEBUG=1` set)
strips the binary like the linux makefile does.

Also fixed build, at least msys2 mingw needs the math [define](https://stackoverflow.com/questions/6563810/m-pi-works-with-math-h-but-not-with-cmath-in-visual-studio#6563891).